### PR TITLE
Fix enddatetime parameter in ReservationSummaries lava block

### DIFF
--- a/com.bemaservices.RoomManagement/Lava/Blocks/ReservationSummariesLavaDataSource.cs
+++ b/com.bemaservices.RoomManagement/Lava/Blocks/ReservationSummariesLavaDataSource.cs
@@ -213,7 +213,7 @@ namespace com.bemaservices.RoomManagement.Lava.Blocks
 
             // Get the Date Range.
             var startDate = settings.GetDateTimeValue( ParameterStartDateTime );
-            var endDate = settings.GetDateTimeValue( ParameterStartDateTime );
+            var endDate = settings.GetDateTimeValue( ParameterEndDateTime );
 
             var reservationService = new ReservationService( rockContext );
             var qry = reservationService.Queryable( reservationQueryOptions );


### PR DESCRIPTION
This PR fixes the issue reported in #50 where including a `startdatetime` parameter in the `ReservationSummaries` lava block would cause no results to be returned.

The existing code used the `startdatetime` parameter as both the start and end date of the filter. This PR changes it to correctly consider both the `startdatetime` and `enddatetime` parameters when filtering the reservations.